### PR TITLE
feat: lone pair support for CGenFF ligands

### DIFF
--- a/crimm/Adaptors/pyCHARMMAdaptors.py
+++ b/crimm/Adaptors/pyCHARMMAdaptors.py
@@ -28,7 +28,7 @@ def _entity_has_lonepairs(entity) -> bool:
     """Check if entity contains any residues with lone pairs (e.g., CGENFF ligands)."""
     res_list = unfold_entities(entity, 'R')
     for res in res_list:
-        if isinstance(res, Heterogen) and len(res.lone_pairs) > 0:
+        if res.lone_pair_dict:
             return True
     return False
 

--- a/crimm/IO/CRDWriter.py
+++ b/crimm/IO/CRDWriter.py
@@ -76,8 +76,9 @@ def _get_atoms_from_entity(entity, include_lonepairs: bool = True) -> List[Atom]
     if include_lonepairs:
         if hasattr(entity, "get_residues"):
             for residue in entity.get_residues():
-                if residue.lone_pair_dict:
-                    atoms.extend(residue.lone_pair_dict.values())
+                lone_pair_dict = getattr(residue, "lone_pair_dict", None)
+                if lone_pair_dict:
+                    atoms.extend(lone_pair_dict.values())
         elif hasattr(entity, "lone_pair_dict") and entity.lone_pair_dict:
             atoms.extend(entity.lone_pair_dict.values())
 

--- a/crimm/IO/CRDWriter.py
+++ b/crimm/IO/CRDWriter.py
@@ -65,22 +65,18 @@ def _get_atoms_from_entity(entity, include_lonepairs: bool = True) -> List[Atom]
     if hasattr(entity, "get_residues"):
         for residue in entity.get_residues():
             atoms.extend(_get_residue_atoms(residue))
+            if include_lonepairs:
+                lp_dict = getattr(residue, "lone_pair_dict", None)
+                if lp_dict:
+                    atoms.extend(lp_dict.values())
     elif isinstance(entity, Residue):
         atoms.extend(_get_residue_atoms(entity))
+        if include_lonepairs and entity.lone_pair_dict:
+            atoms.extend(entity.lone_pair_dict.values())
     elif hasattr(entity, "get_atoms"):
         atoms.extend(list(entity.get_atoms()))
     elif isinstance(entity, Atom):
         atoms.append(entity)
-
-    # Include lone pairs if present and requested
-    if include_lonepairs:
-        if hasattr(entity, "get_residues"):
-            for residue in entity.get_residues():
-                lone_pair_dict = getattr(residue, "lone_pair_dict", None)
-                if lone_pair_dict:
-                    atoms.extend(lone_pair_dict.values())
-        elif hasattr(entity, "lone_pair_dict") and entity.lone_pair_dict:
-            atoms.extend(entity.lone_pair_dict.values())
 
     return atoms
 

--- a/crimm/IO/CRDWriter.py
+++ b/crimm/IO/CRDWriter.py
@@ -76,7 +76,7 @@ def _get_atoms_from_entity(entity, include_lonepairs: bool = True) -> List[Atom]
     if include_lonepairs:
         if hasattr(entity, "get_residues"):
             for residue in entity.get_residues():
-                if hasattr(residue, "lone_pair_dict") and residue.lone_pair_dict:
+                if residue.lone_pair_dict:
                     atoms.extend(residue.lone_pair_dict.values())
         elif hasattr(entity, "lone_pair_dict") and entity.lone_pair_dict:
             atoms.extend(entity.lone_pair_dict.values())

--- a/crimm/IO/PSFReader.py
+++ b/crimm/IO/PSFReader.py
@@ -379,25 +379,48 @@ class PSFReader:
         return cmaps
 
     def _parse_lonepairs(self, line: str) -> List[Dict[str, Any]]:
-        """Parse NUMLP NUMLPH section."""
+        """Parse NUMLP NUMLPH section (psfres.F90:717-733).
+
+        CHARMM format:
+            NUMLP  NUMLPH !NUMLP NUMLPH
+            LPNHOST  LPHPTR  LPWGHT  VALUE1  VALUE2  VALUE3  (per LP)
+            LPHOST(1) LPHOST(2) ... LPHOST(NUMLPH)           (packed)
+        """
         parts = line.split('!')
         nums = parts[0].split()
         nlp = int(nums[0]) if nums else 0
+        numlph = int(nums[1]) if len(nums) > 1 else 0
 
         lonepairs = []
         for _ in range(nlp):
             self._next_line()
             lp_line = self._current_line()
             parts = lp_line.split()
-            if len(parts) >= 6:
-                lonepairs.append({
-                    'host': int(parts[0]),
-                    'lp': int(parts[1]),
-                    'type': parts[2],
-                    'distance': float(parts[3]),
-                    'angle': float(parts[4]),
-                    'dihedral': float(parts[5])
-                })
+            lonepairs.append({
+                'nhost': int(parts[0]),
+                'ptr': int(parts[1]),
+                'weight': parts[2] == 'T' if len(parts) > 2 else False,
+                'values': (
+                    float(parts[3]) if len(parts) > 3 else 0.0,
+                    float(parts[4]) if len(parts) > 4 else 0.0,
+                    float(parts[5]) if len(parts) > 5 else 0.0,
+                ),
+            })
+
+        # Read packed LPHOST array
+        lphost = []
+        if numlph > 0:
+            self._next_line()
+            while len(lphost) < numlph:
+                lphost.extend(int(x) for x in self._current_line().split())
+                if len(lphost) < numlph:
+                    self._next_line()
+
+        # Attach host indices to each LP entry
+        for lp in lonepairs:
+            start = lp['ptr'] - 1  # convert to 0-based
+            n_entries = lp['nhost'] + 1  # nhost + LP atom itself
+            lp['host_indices'] = lphost[start:start + n_entries]
 
         self._line_idx += 1
         return lonepairs

--- a/crimm/IO/PSFWriter.py
+++ b/crimm/IO/PSFWriter.py
@@ -606,10 +606,12 @@ class PSFWriter:
                 # Lone pairs (for CGENFF ligands)
                 if hasattr(residue, "lone_pair_dict") and residue.lone_pair_dict:
                     for lp_name, lp_atom in residue.lone_pair_dict.items():
-                        self._atom_map[lp_atom] = idx
-                        self._atoms.append(lp_atom)
+                        # LP may already be in atom_map via atom_groups
+                        if lp_atom not in self._atom_map:
+                            self._atom_map[lp_atom] = idx
+                            self._atoms.append(lp_atom)
+                            idx += 1
                         self._lp_atoms.add(lp_atom)
-                        idx += 1
                         # Build CHARMM-format LP entry for NUMLP section
                         lp_def = lp_atom.topo_definition
                         if lp_def is not None and lp_def.lonepair_info is not None:

--- a/crimm/IO/PSFWriter.py
+++ b/crimm/IO/PSFWriter.py
@@ -1179,7 +1179,7 @@ class PSFWriter:
             host_indices = []
             for lp_info in self._lonepairs:
                 for atom in lp_info['host_atoms']:
-                    host_indices.append(self._atom_map.get(atom, 0))
+                    host_indices.append(self._atom_map[atom])
             lines.append(self._format_indices(host_indices, items_per_line=8))
 
         return "\n".join(lines)

--- a/crimm/IO/PSFWriter.py
+++ b/crimm/IO/PSFWriter.py
@@ -14,28 +14,11 @@ Format specification (from CHARMM source io/psfres.F90):
 
 import warnings
 from typing import Union, List, Dict, Tuple, Optional, Any
-from dataclasses import dataclass
 from crimm.StructEntities.Atom import Atom
 from crimm.StructEntities.Residue import Residue
 from crimm.StructEntities.Chain import BaseChain
 from crimm.StructEntities.Model import Model
 from crimm.StructEntities.TopoElements import CMap
-
-
-@dataclass
-class LonePairInfo:
-    """Information about a lone pair for PSF output (CHARMM format).
-
-    CHARMM PSF stores LP data as: LPNHOST, LPHPTR, LPWGHT, VALUE1-3
-    plus a packed LPHOST array of atom indices.
-    See psfres.F90:1319-1328.
-    """
-
-    lp_atom: Atom
-    host_atom: Atom
-    distance: float = 0.0
-    angle: float = 0.0
-    dihedral: float = 0.0
 
 
 class PSFWriter:

--- a/crimm/IO/PSFWriter.py
+++ b/crimm/IO/PSFWriter.py
@@ -1167,7 +1167,7 @@ class PSFWriter:
             for lp_info in self._lonepairs:
                 for atom in lp_info['host_atoms']:
                     host_indices.append(self._atom_map.get(atom, 0))
-            lines.append(self._format_indices(host_indices))
+            lines.append(self._format_indices(host_indices, items_per_line=8))
 
         return "\n".join(lines)
 

--- a/crimm/IO/PSFWriter.py
+++ b/crimm/IO/PSFWriter.py
@@ -24,7 +24,12 @@ from crimm.StructEntities.TopoElements import CMap
 
 @dataclass
 class LonePairInfo:
-    """Information about a lone pair for PSF output."""
+    """Information about a lone pair for PSF output (CHARMM format).
+
+    CHARMM PSF stores LP data as: LPNHOST, LPHPTR, LPWGHT, VALUE1-3
+    plus a packed LPHOST array of atom indices.
+    See psfres.F90:1319-1328.
+    """
 
     lp_atom: Atom
     host_atom: Atom
@@ -80,7 +85,8 @@ class PSFWriter:
         self.separate_crystal_segids = separate_crystal_segids
         self._atom_map: Dict[Atom, int] = {}
         self._atoms: List[Atom] = []
-        self._lonepairs: List[LonePairInfo] = []
+        self._lonepairs: List[dict] = []  # CHARMM format LP entries
+        self._lp_atoms: set = set()  # LP atoms for IMOVE=-1
         self._segid_map: Dict[Any, str] = {}  # Maps chain to assigned segid
 
     def validate_for_simulation(
@@ -308,6 +314,7 @@ class PSFWriter:
         self._atom_map = {}
         self._atoms = []
         self._lonepairs = []
+        self._lp_atoms = set()
         self._segid_map = {}
 
         # Validate topology before writing (CHARMM-style pre-generation checks)
@@ -601,32 +608,41 @@ class PSFWriter:
                     for lp_name, lp_atom in residue.lone_pair_dict.items():
                         self._atom_map[lp_atom] = idx
                         self._atoms.append(lp_atom)
+                        self._lp_atoms.add(lp_atom)
                         idx += 1
-                        # Track lone pair info for NUMLP section
-                        # Find host atom from topology definition
-                        if (
-                            hasattr(residue, "topo_definition")
-                            and residue.topo_definition
-                        ):
-                            lp_def = residue.topo_definition.get(lp_name)
-                            if lp_def and hasattr(lp_def, "lonepair_info"):
-                                host_name = lp_def.lonepair_info.get("host")
-                                if host_name and host_name in residue:
-                                    self._lonepairs.append(
-                                        LonePairInfo(
-                                            lp_atom=lp_atom,
-                                            host_atom=residue[host_name],
-                                            distance=lp_def.lonepair_info.get(
-                                                "distance", 0.0
-                                            ),
-                                            angle=lp_def.lonepair_info.get(
-                                                "angle", 0.0
-                                            ),
-                                            dihedral=lp_def.lonepair_info.get(
-                                                "dihedral", 0.0
-                                            ),
-                                        )
-                                    )
+                        # Build CHARMM-format LP entry for NUMLP section
+                        lp_def = lp_atom.topo_definition
+                        if lp_def is not None and lp_def.lonepair_info is not None:
+                            info = lp_def.lonepair_info
+                            lp_type = info['type']
+                            # Build host_atoms list: [LP, host1, host2, ...]
+                            # This matches CHARMM's LPHOST array layout
+                            host_atom_list = [lp_atom]
+                            for h_name in info['host_atoms']:
+                                if h_name in residue:
+                                    host_atom_list.append(residue[h_name])
+                            # Build values triple per CHARMM convention
+                            if lp_type == 'COLI':
+                                nhost = 2
+                                values = (info['distance'], info.get('scale', 0.0), 0.0)
+                            elif lp_type == 'RELA':
+                                nhost = 3
+                                values = (info['distance'], info['angle'], info['dihedral'])
+                            elif lp_type == 'BISE':
+                                nhost = 3
+                                values = (-info['distance'], info['angle'], info['dihedral'])
+                            elif lp_type == 'CENT':
+                                nhost = len(info['host_atoms'])
+                                values = (0.0, 0.0, 0.0)
+                            else:
+                                continue
+                            self._lonepairs.append({
+                                'lp_atom': lp_atom,
+                                'nhost': nhost,
+                                'host_atoms': host_atom_list,
+                                'weight': False,
+                                'values': values,
+                            })
 
         # Warn about skipped chains
         if skipped_chains:
@@ -749,7 +765,9 @@ class PSFWriter:
                 charge = 0.0
                 mass = atom.mass if atom.mass else 0.0
 
-            imove = 0  # Movement flag (0 = free to move, non-zero = constrained)
+            imove = 0  # Movement flag (0=free, -1=lonepair, 1=fixed)
+            if atom in self._lp_atoms:
+                imove = -1
 
             lines.append(
                 self._format_atom_line(
@@ -1105,34 +1123,51 @@ class PSFWriter:
         )
 
     def _write_lonepairs(self) -> str:
-        """Write NUMLP NUMLPH section for lone pairs.
+        """Write NUMLP NUMLPH section (psfres.F90:1319-1328).
 
-        CHARMM always writes this section, even when there are no lone pairs.
+        CHARMM format:
+            NUMLP  NUMLPH !NUMLP NUMLPH
+            LPNHOST  LPHPTR  LPWGHT  VALUE1  VALUE2  VALUE3   (per LP)
+            LPHOST(1) LPHOST(2) ... LPHOST(NUMLPH)            (packed)
+
+        Where NUMLPH = total entries in the packed LPHOST array.
         """
         lines = []
         nlp = len(self._lonepairs)
-        nlph = nlp  # Number of LP hosts
+        # NUMLPH = total number of entries in LPHOST array
+        numlph = sum(len(lp['host_atoms']) for lp in self._lonepairs)
 
         if self.extended:
-            lines.append(f"{nlp:>10d}{nlph:>10d} !NUMLP NUMLPH")
+            lines.append(f"{nlp:>10d}{numlph:>10d} !NUMLP NUMLPH")
         else:
-            lines.append(f"{nlp:>8d}{nlph:>8d} !NUMLP NUMLPH")
+            lines.append(f"{nlp:>8d}{numlph:>8d} !NUMLP NUMLPH")
 
-        # Lone pair host information (only if there are lone pairs)
-        for lp_info in self._lonepairs:
-            host_idx = self._atom_map.get(lp_info.host_atom, 0)
-            lp_idx = self._atom_map.get(lp_info.lp_atom, 0)
-            # Format: host_atom, lp_atom, type, distance, angle, dihedral
-            if self.extended:
-                lines.append(
-                    f"{host_idx:>10d}{lp_idx:>10d}   F"
-                    f"{lp_info.distance:>14.6f}{lp_info.angle:>14.6f}{lp_info.dihedral:>14.6f}"
-                )
-            else:
-                lines.append(
-                    f"{host_idx:>8d}{lp_idx:>8d}   F"
-                    f"{lp_info.distance:>14.6f}{lp_info.angle:>14.6f}{lp_info.dihedral:>14.6f}"
-                )
+        if nlp > 0:
+            # Per-LP lines: LPNHOST, LPHPTR, LPWGHT, VALUE1-3
+            # Format: fmt06 = (2I10,3X,L1,3G14.6) for extended
+            ptr = 1  # 1-based pointer into LPHOST array
+            for lp_info in self._lonepairs:
+                nhost = lp_info['nhost']
+                weight = 'T' if lp_info['weight'] else 'F'
+                v1, v2, v3 = lp_info['values']
+                if self.extended:
+                    lines.append(
+                        f"{nhost:>10d}{ptr:>10d}   {weight}"
+                        f"{v1:>14.6E}{v2:>14.6E}{v3:>14.6E}"
+                    )
+                else:
+                    lines.append(
+                        f"{nhost:>8d}{ptr:>8d}   {weight}"
+                        f"{v1:>14.6E}{v2:>14.6E}{v3:>14.6E}"
+                    )
+                ptr += len(lp_info['host_atoms'])
+
+            # Packed LPHOST array: all host atom indices
+            host_indices = []
+            for lp_info in self._lonepairs:
+                for atom in lp_info['host_atoms']:
+                    host_indices.append(self._atom_map.get(atom, 0))
+            lines.append(self._format_indices(host_indices))
 
         return "\n".join(lines)
 

--- a/crimm/IO/PSFWriter.py
+++ b/crimm/IO/PSFWriter.py
@@ -617,13 +617,7 @@ class PSFWriter:
                         if lp_def is not None and lp_def.lonepair_info is not None:
                             info = lp_def.lonepair_info
                             lp_type = info['type']
-                            # Build host_atoms list: [LP, host1, host2, ...]
-                            # This matches CHARMM's LPHOST array layout
-                            host_atom_list = [lp_atom]
-                            for h_name in info['host_atoms']:
-                                if h_name in residue:
-                                    host_atom_list.append(residue[h_name])
-                            # Build values triple per CHARMM convention
+                            # Determine nhost and values triple per CHARMM convention
                             if lp_type == 'COLI':
                                 nhost = 2
                                 values = (info['distance'], info.get('scale', 0.0), 0.0)
@@ -637,6 +631,23 @@ class PSFWriter:
                                 nhost = len(info['host_atoms'])
                                 values = (0.0, 0.0, 0.0)
                             else:
+                                continue
+                            # Build host_atoms list: [LP, host1, host2, ...]
+                            # This matches CHARMM's LPHOST array layout
+                            host_atom_list = [lp_atom]
+                            for h_name in info['host_atoms']:
+                                if h_name in residue:
+                                    host_atom_list.append(residue[h_name])
+                            # Validate all host atoms were found
+                            if len(host_atom_list) != nhost + 1:
+                                missing = [
+                                    h for h in info['host_atoms']
+                                    if h not in residue
+                                ]
+                                warnings.warn(
+                                    f"LP '{lp_name}' in residue {residue.resname}: "
+                                    f"missing host atoms {missing}, skipping NUMLP entry"
+                                )
                                 continue
                             self._lonepairs.append({
                                 'lp_atom': lp_atom,

--- a/crimm/IO/PSFWriter.py
+++ b/crimm/IO/PSFWriter.py
@@ -604,7 +604,7 @@ class PSFWriter:
                         idx += 1
 
                 # Lone pairs (for CGENFF ligands)
-                if hasattr(residue, "lone_pair_dict") and residue.lone_pair_dict:
+                if residue.lone_pair_dict:
                     for lp_name, lp_atom in residue.lone_pair_dict.items():
                         # LP may already be in atom_map via atom_groups
                         if lp_atom not in self._atom_map:

--- a/crimm/IO/RTFParser.py
+++ b/crimm/IO/RTFParser.py
@@ -172,6 +172,61 @@ def delete_parser(line):
         )
     return (fields[0],fields[1])
 
+# Keywords that signal end of atom names and start of keyword=value pairs
+_LP_VALUE_KEYWORDS = frozenset({
+    'DIST', 'DISTANCE',
+    'ANGL', 'ANGLE',
+    'DIHE', 'DIHED', 'DIHEDRAL',
+    'SCAL', 'SCALE',
+    'MASS',
+})
+
+
+def lonepair_parser(line):
+    """Parse a LONEPAIR directive from an RTF file.
+
+    Handles all 4 types: COLINEAR (COLI), RELATIVE (RELA),
+    BISECTOR (BISE), CENTER (CENT).
+
+    CHARMM matches type by first 4 characters, uppercased (rtfio.F90:581,1967).
+    Value keywords (DIST, ANGL, DIHE, SCAL) are case-insensitive.
+    """
+    field_str = comment_parser(line)[0]
+    tokens = field_str.split()
+    # tokens[0] = 'LONEPAIR' (or 'LONE' etc.)
+    # tokens[1] = type keyword
+    lp_type = tokens[1][:4].upper()
+
+    # Separate atom names from keyword=value pairs
+    atom_names = []
+    kv_pairs = {}
+    i = 2
+    while i < len(tokens):
+        if tokens[i].upper() in _LP_VALUE_KEYWORDS:
+            key = tokens[i].upper()[:4]
+            if i + 1 < len(tokens):
+                kv_pairs[key] = float(tokens[i + 1])
+                i += 2
+            else:
+                i += 1
+        else:
+            atom_names.append(tokens[i])
+            i += 1
+
+    lp_atom = atom_names[0] if atom_names else ''
+    host_atoms = atom_names[1:] if len(atom_names) > 1 else []
+
+    return {
+        'type': lp_type,
+        'lp_atom': lp_atom,
+        'host_atoms': host_atoms,
+        'distance': kv_pairs.get('DIST', 0.0),
+        'angle': kv_pairs.get('ANGL', 0.0),
+        'dihedral': kv_pairs.get('DIHE', 0.0),
+        'scale': kv_pairs.get('SCAL', 0.0),
+    }
+
+
 class RTFParser:
     """A parser class to load rtf (residue topology files) into dictionary.
     Parser is initialized with RTF file from file path. If any lines from the 
@@ -234,6 +289,7 @@ class RTFParser:
                         },
                         'impropers':[],
                         'cmap':[],
+                        'lonepairs': [],
                         'ic':{},
                         'is_patch': l.startswith('PRES')
                     }
@@ -308,6 +364,9 @@ class RTFParser:
                 # Internal Coordinates
                 ic_key, ic_param_dict = ic_parser(l)
                 cur_res['ic'][ic_key] = ic_param_dict
+            elif l.startswith('LONE'):
+                lp_entry = lonepair_parser(l)
+                cur_res['lonepairs'].append(lp_entry)
             elif l.startswith('DELE'):
                 if 'delete' not in cur_res:
                     cur_res['delete'] = []

--- a/crimm/IO/RTFParser.py
+++ b/crimm/IO/RTFParser.py
@@ -221,8 +221,8 @@ def lonepair_parser(line):
         raise ValueError(
             f"LONEPAIR directive has no atom names: '{field_str.strip()}'"
         )
-    lp_atom = atom_names[0] if atom_names else ''
-    host_atoms = atom_names[1:] if len(atom_names) > 1 else []
+    lp_atom = atom_names[0]
+    host_atoms = atom_names[1:]
 
     return {
         'type': lp_type,

--- a/crimm/IO/RTFParser.py
+++ b/crimm/IO/RTFParser.py
@@ -193,6 +193,10 @@ def lonepair_parser(line):
     """
     field_str = comment_parser(line)[0]
     tokens = field_str.split()
+    if len(tokens) < 2:
+        raise ValueError(
+            f"Malformed LONEPAIR directive (no type keyword): '{field_str.strip()}'"
+        )
     # tokens[0] = 'LONEPAIR' (or 'LONE' etc.)
     # tokens[1] = type keyword
     lp_type = tokens[1][:4].upper()
@@ -213,6 +217,10 @@ def lonepair_parser(line):
             atom_names.append(tokens[i])
             i += 1
 
+    if len(atom_names) < 1:
+        raise ValueError(
+            f"LONEPAIR directive has no atom names: '{field_str.strip()}'"
+        )
     lp_atom = atom_names[0] if atom_names else ''
     host_atoms = atom_names[1:] if len(atom_names) > 1 else []
 

--- a/crimm/Modeller/LonePairBuilder.py
+++ b/crimm/Modeller/LonePairBuilder.py
@@ -92,7 +92,7 @@ def build_lonepair_coords(entity):
     """
     count = 0
     for residue in entity.get_residues():
-        if not hasattr(residue, 'lone_pair_dict') or not residue.lone_pair_dict:
+        if not residue.lone_pair_dict:
             continue
         for lp_name, lp_atom in residue.lone_pair_dict.items():
             lp_def = lp_atom.topo_definition

--- a/crimm/Modeller/LonePairBuilder.py
+++ b/crimm/Modeller/LonePairBuilder.py
@@ -146,6 +146,6 @@ def build_lonepair_coords(entity):
                     warnings.warn(f"Unknown LP type '{lp_type}' for {lp_name}")
                     continue
                 count += 1
-            except Exception as e:
+            except (ValueError, LA.LinAlgError) as e:
                 warnings.warn(f"Failed to build LP {lp_name}: {e}")
     return count

--- a/crimm/Modeller/LonePairBuilder.py
+++ b/crimm/Modeller/LonePairBuilder.py
@@ -1,0 +1,151 @@
+"""Build lone pair coordinates from host atom positions.
+
+Implements CHARMM's LONEPRC subroutine (lonepair.F90:617-820).
+Supports all 4 LP geometry types: COLINEAR, RELATIVE, BISECTOR, CENTER.
+"""
+import warnings
+
+import numpy as np
+from numpy import linalg as LA
+
+
+def build_colinear_coord(j_coord, k_coord, distance, scale=0.0):
+    """Place LP along the J->K bond axis, on the far side of J from K.
+
+    From LONEPRC (N=2 case, lonepair.F90:738-757):
+        r_JK = J - K
+        dr = scale + distance / |r_JK|
+        LP = J + dr * r_JK
+
+    Parameters
+    ----------
+    j_coord : ndarray
+        Host atom position (the atom LP is attached to)
+    k_coord : ndarray
+        Bonded-to atom position (defines the bond axis)
+    distance : float
+        LP distance parameter (DIST from RTF)
+    scale : float
+        Scale factor (SCAL from RTF, default 0.0)
+    """
+    r_jk = j_coord - k_coord
+    norm = LA.norm(r_jk)
+    if norm < 1e-5:
+        raise ValueError("COLINEAR host atoms at same position")
+    dr = scale + distance / norm
+    return j_coord + dr * r_jk
+
+
+def build_relative_coord(j_coord, k_coord, l_coord, distance, angle, dihedral):
+    """Place LP via internal coordinate (CARTCV) from 3 host atoms.
+
+    From LONEPRC (N=3, V1>0 case, lonepair.F90:780-782):
+        CALL CARTCV(X,Y,Z, L, K, J, I, V1, V2, V3, OK)
+
+    The LP is built as atom I from reference atoms L, K, J using
+    bond=distance, angle=angle, dihedral=dihedral.
+    """
+    from crimm.Modeller.TopoFixer import get_coord_from_dihedral_ic
+    return get_coord_from_dihedral_ic(
+        l_coord, k_coord, j_coord, dihedral, angle, distance
+    )
+
+
+def build_bisector_coord(j_coord, k_coord, l_coord, distance, angle, dihedral):
+    """Place LP at angle bisector of K-J-L, then via CARTCV.
+
+    From LONEPRC (N=3, V1<0 case, lonepair.F90:783-789):
+        mid = (K + L) / 2
+        CALL CARTCV(X,Y,Z, L, mid, J, I, |V1|, V2, V3, OK)
+    """
+    from crimm.Modeller.TopoFixer import get_coord_from_dihedral_ic
+    mid = (k_coord + l_coord) / 2.0
+    return get_coord_from_dihedral_ic(
+        l_coord, mid, j_coord, dihedral, angle, distance
+    )
+
+
+def build_center_coord(host_coords):
+    """Place LP at center of geometry of host atoms.
+
+    From LONEPRC (QCENT case, lonepair.F90:792-809):
+        LP = mean(host positions)
+    """
+    return np.mean(host_coords, axis=0)
+
+
+def build_lonepair_coords(entity):
+    """Position all lone pair atoms in an entity from their host coordinates.
+
+    Iterates over all residues, finds LP atoms with lonepair_info,
+    and computes their coordinates based on the geometry type.
+
+    Parameters
+    ----------
+    entity : Model, Chain, or OrganizedModel
+        Entity containing residues with lone_pair_dict populated.
+
+    Returns
+    -------
+    int
+        Number of LP atoms positioned.
+    """
+    count = 0
+    for residue in entity.get_residues():
+        if not hasattr(residue, 'lone_pair_dict') or not residue.lone_pair_dict:
+            continue
+        for lp_name, lp_atom in residue.lone_pair_dict.items():
+            lp_def = lp_atom.topo_definition
+            if lp_def is None or lp_def.lonepair_info is None:
+                continue
+            info = lp_def.lonepair_info
+            lp_type = info['type']
+            hosts = info['host_atoms']
+
+            # Validate all host atoms exist with coordinates
+            host_coords = []
+            valid = True
+            for h in hosts:
+                if h not in residue:
+                    warnings.warn(
+                        f"LP {lp_name}: host atom {h} not found in residue "
+                        f"{residue.resname} {residue.id[1]}"
+                    )
+                    valid = False
+                    break
+                h_coord = residue[h].coord
+                if h_coord is None:
+                    warnings.warn(
+                        f"LP {lp_name}: host atom {h} has no coordinates"
+                    )
+                    valid = False
+                    break
+                host_coords.append(h_coord)
+            if not valid:
+                continue
+
+            try:
+                if lp_type == 'COLI':
+                    lp_atom.coord = build_colinear_coord(
+                        host_coords[0], host_coords[1],
+                        info['distance'], info.get('scale', 0.0)
+                    )
+                elif lp_type == 'RELA':
+                    lp_atom.coord = build_relative_coord(
+                        host_coords[0], host_coords[1], host_coords[2],
+                        info['distance'], info['angle'], info['dihedral']
+                    )
+                elif lp_type == 'BISE':
+                    lp_atom.coord = build_bisector_coord(
+                        host_coords[0], host_coords[1], host_coords[2],
+                        info['distance'], info['angle'], info['dihedral']
+                    )
+                elif lp_type == 'CENT':
+                    lp_atom.coord = build_center_coord(host_coords)
+                else:
+                    warnings.warn(f"Unknown LP type '{lp_type}' for {lp_name}")
+                    continue
+                count += 1
+            except Exception as e:
+                warnings.warn(f"Failed to build LP {lp_name}: {e}")
+    return count

--- a/crimm/Modeller/TopoLoader.py
+++ b/crimm/Modeller/TopoLoader.py
@@ -1406,7 +1406,9 @@ class TopologyGenerator:
         """Create and separate missing heavy atoms and missing hydrogen atom by atom name"""
         missing_atom: Atom = residue.topo_definition[atom_name].create_new_atom()
         missing_atom.set_parent(residue)
-        if atom_name.startswith("H"):
+        if atom_name.startswith('LP') and hasattr(residue, 'lone_pair_dict'):
+            residue.lone_pair_dict[atom_name] = missing_atom
+        elif atom_name.startswith('H'):
             residue.missing_hydrogens[atom_name] = missing_atom
         else:
             residue.missing_atoms[atom_name] = missing_atom

--- a/crimm/Modeller/TopoLoader.py
+++ b/crimm/Modeller/TopoLoader.py
@@ -1406,7 +1406,7 @@ class TopologyGenerator:
         """Create and separate missing heavy atoms and missing hydrogen atom by atom name"""
         missing_atom: Atom = residue.topo_definition[atom_name].create_new_atom()
         missing_atom.set_parent(residue)
-        if atom_name.startswith('LP') and hasattr(residue, 'lone_pair_dict'):
+        if atom_name.startswith('LP'):
             residue.lone_pair_dict[atom_name] = missing_atom
         elif atom_name.startswith('H'):
             residue.missing_hydrogens[atom_name] = missing_atom

--- a/crimm/StructEntities/Residue.py
+++ b/crimm/StructEntities/Residue.py
@@ -50,7 +50,10 @@ class Residue(_Residue):
     def total_charge(self):
         """Return the total charge of the residue, including lone pairs."""
         total_charge = 0
+        lp_atoms = set(self.lone_pair_dict.values())
         for atom in self.child_list:
+            if atom in lp_atoms:
+                continue
             if atom.topo_definition is None:
                 return None
             total_charge += atom.topo_definition.charge

--- a/crimm/StructEntities/Residue.py
+++ b/crimm/StructEntities/Residue.py
@@ -50,6 +50,14 @@ class Residue(_Residue):
     def total_charge(self):
         """Return the total charge of the residue, including lone pairs."""
         total_charge = 0
+        if not self.lone_pair_dict:
+            for atom in self.child_list:
+                if atom.topo_definition is None:
+                    return None
+                total_charge += atom.topo_definition.charge
+            return round(total_charge, 2)
+        # Slow path: deduplicate LP atoms that may be in both child_list
+        # and lone_pair_dict (LP atoms are virtual sites, not regular children)
         lp_atoms = set(self.lone_pair_dict.values())
         for atom in self.child_list:
             if atom in lp_atoms:
@@ -57,7 +65,7 @@ class Residue(_Residue):
             if atom.topo_definition is None:
                 return None
             total_charge += atom.topo_definition.charge
-        for lp in self.lone_pairs:
+        for lp in lp_atoms:
             if lp.topo_definition is not None:
                 total_charge += lp.topo_definition.charge
         return round(total_charge, 2)

--- a/crimm/StructEntities/Residue.py
+++ b/crimm/StructEntities/Residue.py
@@ -44,21 +44,42 @@ class Residue(_Residue):
         self.is_patch = None
         self.param_desc = None
         self.undefined_atoms = None
-    
+        self.lone_pair_dict = {}
+
     @property
     def total_charge(self):
-        """Return the total charge of the residue."""
+        """Return the total charge of the residue, including lone pairs."""
         total_charge = 0
         for atom in self.child_list:
             if atom.topo_definition is None:
                 return None
             total_charge += atom.topo_definition.charge
+        for lp in self.lone_pairs:
+            if lp.topo_definition is not None:
+                total_charge += lp.topo_definition.charge
         return round(total_charge, 2)
 
     @property
     def atoms(self):
         """Alias for child_list. Return the list of atoms in the residue."""
         return self.child_list
+
+    @property
+    def lone_pairs(self):
+        """Return the list of lone pairs in the residue."""
+        return list(self.lone_pair_dict.values())
+
+    def __getitem__(self, id):
+        """Return the child with given id, including lone pairs."""
+        try:
+            return super().__getitem__(id)
+        except KeyError:
+            if id in self.lone_pair_dict:
+                return self.lone_pair_dict[id]
+            raise
+
+    def __contains__(self, id):
+        return super().__contains__(id) or id in self.lone_pair_dict
     
     def get_atoms(self, include_alt=False):
         """Return the list of all atoms. If include_alt is True, all altloc of 
@@ -150,33 +171,9 @@ class Heterogen(Residue):
         super().__init__(res_id, resname, segid)
         self.pdbx_description = None
         self._rdkit_mol = rdkit_mol
-        self.lone_pair_dict = {}
-        # This is for the purpose of visualization and rdkit mol conversion. 
+        # This is for the purpose of visualization and rdkit mol conversion.
         # The actual bond information should stored in the topo_definition attribute.
         self._bonds = None
-
-    def __getitem__(self, id):
-        """Return the child with given id."""
-        return {**self.child_dict, **self.lone_pair_dict}[id]
-    
-    def __contains__(self, id):
-        return super().__contains__(id) or id in self.lone_pair_dict
-    
-    @property
-    def lone_pairs(self):
-        """Return the list of lone pairs in the residue."""
-        return list(self.lone_pair_dict.values())
-
-    @property
-    def total_charge(self):
-        """Return the total charge of the residue."""
-        total_charge = super().total_charge
-        if total_charge is None:
-            return None
-        for lp in self.lone_pairs:
-            if lp.topo_definition is not None:
-                total_charge += lp.topo_definition.charge
-        return round(total_charge, 2)
 
     @property
     def bonds(self):

--- a/crimm/StructEntities/TopoDefinitions.py
+++ b/crimm/StructEntities/TopoDefinitions.py
@@ -23,11 +23,12 @@ class AtomDefinition:
         self.mass = mass
         self.desc = desc
         self.element = element
+        self.lonepair_info = None
         if element is None:
             # if element is not specified, take the first letter of the atom name
             # as the element
             # TODO: this is not a good way to determine the element
-            self.element = name[0] 
+            self.element = name[0]
 
     def __repr__(self):
         repr_str = f"<Atom Definition name={self.name} type={self.atom_type}>"
@@ -114,6 +115,10 @@ class ResidueDefinition:
         """Check if there is an atom element with the given atom name."""
         return id in self.atom_dict
 
+    def get(self, id, default=None):
+        """Return atom definition by name, or default if not found."""
+        return self.atom_dict.get(id, default)
+
     def __iter__(self):
         """Iterate over atom definitions."""
         yield from self.atom_dict.values()
@@ -125,8 +130,26 @@ class ResidueDefinition:
         for key, val in res_topo_dict.items():
             if key == 'atoms':
                 self.process_atom_groups(val)
+            elif key == 'lonepairs':
+                self._process_lonepairs(val)
             else:
                 setattr(self, key, val)
+
+    def _process_lonepairs(self, lonepair_list):
+        """Attach lonepair_info to the corresponding AtomDefinitions."""
+        for lp_entry in lonepair_list:
+            lp_name = lp_entry['lp_atom']
+            if lp_name not in self.atom_dict:
+                continue
+            self.atom_dict[lp_name].lonepair_info = {
+                'type': lp_entry['type'],
+                'host': lp_entry['host_atoms'][0] if lp_entry['host_atoms'] else None,
+                'host_atoms': lp_entry['host_atoms'],
+                'distance': lp_entry['distance'],
+                'angle': lp_entry['angle'],
+                'dihedral': lp_entry['dihedral'],
+                'scale': lp_entry.get('scale', 0.0),
+            }
 
     def process_atom_groups(self, atom_dict):
         self.atom_groups = []

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "crimm"
-version = "2026.1.6"
+version = "2026.1.7"
 authors = [
   { name="Truman Xu", email="ziqiaoxu@umich.edu" },
   { name="Stanislav Cherepanov", email="stanislc@umich.edu" },


### PR DESCRIPTION
## Summary

- Parse `LONEPAIR` directives from CHARMM RTF files (all 4 types: COLINEAR, RELATIVE, BISECTOR, CENTER)
- Wire `lonepair_info` to `AtomDefinition` via `ResidueDefinition._process_lonepairs`
- Build LP coordinates from host atom positions (`LonePairBuilder.py`)
- Rewrite PSF `NUMLP` section to match CHARMM's pointer+packed array format
- Set `IMOVE=-1` for LP atoms in PSF atom section
- Route LP atoms to `lone_pair_dict` in `_create_missing_atom`
- Fix duplicate LP atom when present in both `atom_groups` and `lone_pair_dict`
- Update `PSFReader` to parse the correct CHARMM NUMLP format

## Validation

Tested against pyCHARMM with a CGenFF ligand (molecule 13, chlorinated aromatic with 1 COLINEAR LP):
- CRIMM PSF produces **identical energy** to CHARMM-generated PSF (diff = 0.000000 kcal/mol across all terms)
- All 104 LONEPAIR lines in bundled RTF files (66 cgenff.rtf + 38 prot_modify_res.rtf) parse correctly
- SD minimization runs successfully with CRIMM-generated PSF/CRD

## Test plan

- [x] CRIMM PSF vs CHARMM PSF energy comparison (all terms match)
- [x] pyCHARMM loads CRIMM PSF/CRD without errors
- [x] SD minimization (100 steps) converges
- [x] 4PTI protein-only regression (NUMLP=0, no change)
- [x] All bundled RTF files: zero unparsed LONEPAIR lines