### PR TITLE
fix: handle PDB parser chain ids beyond 26

### DIFF
--- a/crimm/Adaptors/RDKitConverter.py
+++ b/crimm/Adaptors/RDKitConverter.py
@@ -644,7 +644,7 @@ def heterogen_to_rdkit(het_res, smiles=None):
         rdkit.Chem.rdchem.Mol: The rdkit mol of the heterogen.
     """
     mol = Chem.MolFromPDBBlock(
-        get_pdb_str(het_res, pdb_compatible_chain_ids=True)
+        get_pdb_str(het_res, chain_id_policy='renumber')
     )
     if smiles is None:
         smiles = query_rcsb_for_smiles(het_res)

--- a/crimm/Adaptors/RDKitConverter.py
+++ b/crimm/Adaptors/RDKitConverter.py
@@ -643,7 +643,9 @@ def heterogen_to_rdkit(het_res, smiles=None):
     Returns:
         rdkit.Chem.rdchem.Mol: The rdkit mol of the heterogen.
     """
-    mol = Chem.MolFromPDBBlock(get_pdb_str(het_res))
+    mol = Chem.MolFromPDBBlock(
+        get_pdb_str(het_res, pdb_compatible_chain_ids=True)
+    )
     if smiles is None:
         smiles = query_rcsb_for_smiles(het_res)
     # We do not allow rdkit mol return if the correct bond orders are not set

--- a/crimm/Adaptors/charmm_struct_prep.py
+++ b/crimm/Adaptors/charmm_struct_prep.py
@@ -5,6 +5,7 @@ from crimm.Modeller.TopoFixer import fix_chain
 from crimm.StructEntities.Model import Model
 import crimm.Adaptors.pyCHARMMAdaptors as pcm_interface
 from crimm.Adaptors.PropKaAdaptors import PropKaProtonator
+from crimm.Utils.StructureUtils import polymer_chain_to_charmm_segid
 
 from pycharmm.psf import delete_atoms as pcm_del_atoms
 from pycharmm.psf import get_natom as pcm_get_natom
@@ -74,7 +75,7 @@ def protonate_and_patch(model, pH, rtf_loader, param_loader):
 
     for chain_id, patch_dict in protonator.patches.items():
         for resid, patch_name in patch_dict.items():
-            pcm_patch(patch_name, f'PRO{chain_id} {resid}')
+            pcm_patch(patch_name, f'{polymer_chain_to_charmm_segid(model[chain_id])} {resid}')
 
 def load_pdbid_in_charmm(
     pdb_id,
@@ -171,7 +172,10 @@ def load_pdbid_in_charmm(
         for res1, res2 in structure.models[0].connect_dict['disulf']:
             seg1, seg2 = res1['chain'], res2['chain']
             seq1, seq2 = res1['resseq'], res2['resseq']
-            patch_arg = f'PRO{seg1} {seq1} PRO{seg2} {seq2}'
+            patch_arg = (
+                f'{polymer_chain_to_charmm_segid(new_model[seg1])} {seq1} '
+                f'{polymer_chain_to_charmm_segid(new_model[seg2])} {seq2}'
+            )
             pcm_patch('DISU', patch_arg)
 
     return structure

--- a/crimm/Adaptors/pyCHARMMAdaptors.py
+++ b/crimm/Adaptors/pyCHARMMAdaptors.py
@@ -69,15 +69,20 @@ def _get_polymer_segid(chain, legacy_pdb_compatible: bool = False) -> str:
     """Return the segid used for a polymer chain in the selected loading mode."""
     if chain.chain_type == 'Polyribonucleotide':
         prefix = 'NUC'
-        legacy_prefix = 'N'
+        legacy_two_char_prefix = 'NR'
+        legacy_fallback_prefix = 'N'
     else:
         prefix = 'PRO'
-        legacy_prefix = 'P'
+        legacy_two_char_prefix = 'PR'
+        legacy_fallback_prefix = 'P'
 
-    segid = f'{prefix}{chain.id}'
+    chain_id = chain.id.upper()
+    segid = f'{prefix}{chain_id}'
     if not legacy_pdb_compatible or len(segid) <= 4:
         return segid
-    return f'{legacy_prefix}{_compact_legacy_chain_id(chain.id)}'
+    if len(chain_id) == 2 and chain_id.isalnum():
+        return f'{legacy_two_char_prefix}{chain_id}'
+    return f'{legacy_fallback_prefix}{_compact_legacy_chain_id(chain_id)}'
 
 def empty_charmm():
     """If any atom exists in current CHARMM runtime, remove them."""

--- a/crimm/Adaptors/pyCHARMMAdaptors.py
+++ b/crimm/Adaptors/pyCHARMMAdaptors.py
@@ -2,7 +2,6 @@ import tempfile
 import warnings
 import numpy as np
 from pathlib import Path
-from string import digits, ascii_uppercase
 
 import pycharmm as pcm
 from pycharmm import read, psf, coor
@@ -18,71 +17,7 @@ from crimm.IO.PDBString import get_pdb_str
 from crimm.IO import write_psf, write_crd
 from crimm.Modeller.LonePairBuilder import build_lonepair_coords
 from crimm.Data.components_dict import nucleic_letters_1to3
-from crimm.Utils.StructureUtils import letters_to_index
-
-
-_BASE36_ALPHABET = digits + ascii_uppercase
-
-
-def _to_base36(value: int) -> str:
-    """Encode a non-negative integer as an uppercase base36 string."""
-    if value < 0:
-        raise ValueError("value must be non-negative")
-    if value == 0:
-        return "0"
-
-    encoded = []
-    while value:
-        value, remainder = divmod(value, 36)
-        encoded.append(_BASE36_ALPHABET[remainder])
-    return "".join(reversed(encoded))
-
-
-def _compact_legacy_chain_id(chain_id: str, max_len: int = 3) -> str:
-    """Return a CHARMM-PDB-safe token for legacy 4-character segids.
-
-    The deprecated PDB loading path writes CHARMM-format PDB records with a
-    4-character SEGID field. Preserve the existing PRO*/NUC* style when it fits;
-    otherwise compact alphabetic rollover chain IDs into <=3 characters so a
-    one-character type prefix can still produce a unique legacy segid.
-    """
-    chain_id = chain_id.upper()
-    if len(chain_id) <= max_len and chain_id.isalnum():
-        return chain_id
-    if not chain_id.isalpha():
-        raise ValueError(
-            f"Legacy PDB-based CHARMM loading cannot compact chain ID '{chain_id}'. "
-            "Use the default PSF/CRD loading path instead."
-        )
-
-    compact = _to_base36(letters_to_index(chain_id))
-    if len(compact) > max_len:
-        raise ValueError(
-            f"Legacy PDB-based CHARMM loading cannot represent chain ID '{chain_id}' "
-            "within CHARMM's 4-character SEGID limit. Use the default PSF/CRD "
-            "loading path instead."
-        )
-    return compact
-
-
-def _get_polymer_segid(chain, legacy_pdb_compatible: bool = False) -> str:
-    """Return the segid used for a polymer chain in the selected loading mode."""
-    if chain.chain_type == 'Polyribonucleotide':
-        prefix = 'NUC'
-        legacy_two_char_prefix = 'NR'
-        legacy_fallback_prefix = 'N'
-    else:
-        prefix = 'PRO'
-        legacy_two_char_prefix = 'PR'
-        legacy_fallback_prefix = 'P'
-
-    chain_id = chain.id.upper()
-    segid = f'{prefix}{chain_id}'
-    if not legacy_pdb_compatible or len(segid) <= 4:
-        return segid
-    if len(chain_id) == 2 and chain_id.isalnum():
-        return f'{legacy_two_char_prefix}{chain_id}'
-    return f'{legacy_fallback_prefix}{_compact_legacy_chain_id(chain_id)}'
+from crimm.Utils.StructureUtils import polymer_chain_to_charmm_segid
 
 def empty_charmm():
     """If any atom exists in current CHARMM runtime, remove them."""
@@ -269,8 +204,8 @@ def load_chain(chain, hbuild=False, report=False, use_psf_crd=True, append=False
     if not chain.is_continuous():
         raise ValueError("Chain is not continuous! Fix the chain first!")
 
-    # Determine segment ID based on chain type
-    segid = _get_polymer_segid(chain, legacy_pdb_compatible=not use_psf_crd)
+    # Use the shared CHARMM SEGID policy for all loading modes.
+    segid = polymer_chain_to_charmm_segid(chain)
 
     # Set segid on all residues
     for res in chain:
@@ -605,7 +540,7 @@ def load_model(model, use_psf_crd=True, load_params=True, separate_crystal_segid
             load_ions(model.ion, use_psf_crd=False)
         
         # Apply disulfide patches (only needed for PDB-based loading)
-        patch_disu_from_model(model, legacy_pdb_compatible=True)
+        patch_disu_from_model(model)
 
 def _get_charmm_named_chain(chain, segid):
     for res in chain:
@@ -647,16 +582,12 @@ def _load_chain(
     if hbuild:
         pcm.lingo.charmm_script("hbuild sele type H* end")
 
-def patch_disu_from_model(model, legacy_pdb_compatible=False):
+def patch_disu_from_model(model):
     """Patch disulfide bonds found in a model object."""
     if 'disulf' in model.connect_dict:
         for res1, res2 in model.connect_dict['disulf']:
-            seg1 = _get_polymer_segid(
-                model[res1['chain']], legacy_pdb_compatible=legacy_pdb_compatible
-            )
-            seg2 = _get_polymer_segid(
-                model[res2['chain']], legacy_pdb_compatible=legacy_pdb_compatible
-            )
+            seg1 = polymer_chain_to_charmm_segid(model[res1['chain']])
+            seg2 = polymer_chain_to_charmm_segid(model[res2['chain']])
             seq1, seq2 = res1['resseq'], res2['resseq']
             patch_arg = f'{seg1} {seq1} {seg2} {seq2}'
             print('[Excuting CHARMM Command] patch DISU', patch_arg)

--- a/crimm/Adaptors/pyCHARMMAdaptors.py
+++ b/crimm/Adaptors/pyCHARMMAdaptors.py
@@ -2,6 +2,7 @@ import tempfile
 import warnings
 import numpy as np
 from pathlib import Path
+from string import digits, ascii_uppercase
 
 import pycharmm as pcm
 from pycharmm import read, psf, coor
@@ -17,6 +18,66 @@ from crimm.IO.PDBString import get_pdb_str
 from crimm.IO import write_psf, write_crd
 from crimm.Modeller.LonePairBuilder import build_lonepair_coords
 from crimm.Data.components_dict import nucleic_letters_1to3
+from crimm.Utils.StructureUtils import letters_to_index
+
+
+_BASE36_ALPHABET = digits + ascii_uppercase
+
+
+def _to_base36(value: int) -> str:
+    """Encode a non-negative integer as an uppercase base36 string."""
+    if value < 0:
+        raise ValueError("value must be non-negative")
+    if value == 0:
+        return "0"
+
+    encoded = []
+    while value:
+        value, remainder = divmod(value, 36)
+        encoded.append(_BASE36_ALPHABET[remainder])
+    return "".join(reversed(encoded))
+
+
+def _compact_legacy_chain_id(chain_id: str, max_len: int = 3) -> str:
+    """Return a CHARMM-PDB-safe token for legacy 4-character segids.
+
+    The deprecated PDB loading path writes CHARMM-format PDB records with a
+    4-character SEGID field. Preserve the existing PRO*/NUC* style when it fits;
+    otherwise compact alphabetic rollover chain IDs into <=3 characters so a
+    one-character type prefix can still produce a unique legacy segid.
+    """
+    chain_id = chain_id.upper()
+    if len(chain_id) <= max_len and chain_id.isalnum():
+        return chain_id
+    if not chain_id.isalpha():
+        raise ValueError(
+            f"Legacy PDB-based CHARMM loading cannot compact chain ID '{chain_id}'. "
+            "Use the default PSF/CRD loading path instead."
+        )
+
+    compact = _to_base36(letters_to_index(chain_id))
+    if len(compact) > max_len:
+        raise ValueError(
+            f"Legacy PDB-based CHARMM loading cannot represent chain ID '{chain_id}' "
+            "within CHARMM's 4-character SEGID limit. Use the default PSF/CRD "
+            "loading path instead."
+        )
+    return compact
+
+
+def _get_polymer_segid(chain, legacy_pdb_compatible: bool = False) -> str:
+    """Return the segid used for a polymer chain in the selected loading mode."""
+    if chain.chain_type == 'Polyribonucleotide':
+        prefix = 'NUC'
+        legacy_prefix = 'N'
+    else:
+        prefix = 'PRO'
+        legacy_prefix = 'P'
+
+    segid = f'{prefix}{chain.id}'
+    if not legacy_pdb_compatible or len(segid) <= 4:
+        return segid
+    return f'{legacy_prefix}{_compact_legacy_chain_id(chain.id)}'
 
 def empty_charmm():
     """If any atom exists in current CHARMM runtime, remove them."""
@@ -204,10 +265,7 @@ def load_chain(chain, hbuild=False, report=False, use_psf_crd=True, append=False
         raise ValueError("Chain is not continuous! Fix the chain first!")
 
     # Determine segment ID based on chain type
-    if chain.chain_type == 'Polyribonucleotide':
-        segid = f'NUC{chain.id}'
-    else:
-        segid = f'PRO{chain.id}'
+    segid = _get_polymer_segid(chain, legacy_pdb_compatible=not use_psf_crd)
 
     # Set segid on all residues
     for res in chain:
@@ -542,7 +600,7 @@ def load_model(model, use_psf_crd=True, load_params=True, separate_crystal_segid
             load_ions(model.ion, use_psf_crd=False)
         
         # Apply disulfide patches (only needed for PDB-based loading)
-        patch_disu_from_model(model)
+        patch_disu_from_model(model, legacy_pdb_compatible=True)
 
 def _get_charmm_named_chain(chain, segid):
     for res in chain:
@@ -584,13 +642,18 @@ def _load_chain(
     if hbuild:
         pcm.lingo.charmm_script("hbuild sele type H* end")
 
-def patch_disu_from_model(model):
+def patch_disu_from_model(model, legacy_pdb_compatible=False):
     """Patch disulfide bonds found in a model object."""
     if 'disulf' in model.connect_dict:
         for res1, res2 in model.connect_dict['disulf']:
-            seg1, seg2 = res1['chain'], res2['chain']
+            seg1 = _get_polymer_segid(
+                model[res1['chain']], legacy_pdb_compatible=legacy_pdb_compatible
+            )
+            seg2 = _get_polymer_segid(
+                model[res2['chain']], legacy_pdb_compatible=legacy_pdb_compatible
+            )
             seq1, seq2 = res1['resseq'], res2['resseq']
-            patch_arg = f'PRO{seg1} {seq1} PRO{seg2} {seq2}'
+            patch_arg = f'{seg1} {seq1} {seg2} {seq2}'
             print('[Excuting CHARMM Command] patch DISU', patch_arg)
             generate.patch('DISU', patch_arg)
 

--- a/crimm/Adaptors/pyCHARMMAdaptors.py
+++ b/crimm/Adaptors/pyCHARMMAdaptors.py
@@ -205,9 +205,9 @@ def load_chain(chain, hbuild=False, report=False, use_psf_crd=True, append=False
 
     # Determine segment ID based on chain type
     if chain.chain_type == 'Polyribonucleotide':
-        segid = f'NUC{chain.id[0]}'
+        segid = f'NUC{chain.id}'
     else:
-        segid = f'PRO{chain.id[0]}'
+        segid = f'PRO{chain.id}'
 
     # Set segid on all residues
     for res in chain:

--- a/crimm/IO/PDBParser.py
+++ b/crimm/IO/PDBParser.py
@@ -11,6 +11,16 @@ from crimm.StructEntities.Chain import Solvent, Heterogens, PolymerChain, Chain,
 from crimm.Data.components_dict import CHARMM_PDB_ION_NAMES
 
 protein_letters_3to1.update({'HSD': 'H', 'HSE': 'H', 'HSP': 'H'})
+
+
+def _index_to_chain_id(index, chain_id=''):
+    """Return spreadsheet-style chain IDs for indices beyond 25."""
+    chain_id = ascii_uppercase[index % 26] + chain_id
+    if (next_index := index // 26) > 0:
+        return _index_to_chain_id(next_index - 1, chain_id)
+    return chain_id
+
+
 def check_chain_type(residues, resname_lookup, extended_lookup=None):
     for res in residues:
         if res.resname not in resname_lookup:
@@ -81,12 +91,12 @@ def convert_chains(chains):
     }
 
     new_chains = []
-    for i, (chain_type, auth_chain_id, residues) in enumerate(
+    for chain_type, auth_chain_id, residues in (
         sorted(organized_residues, key=lambda x: chain_sort_dict[x[0]])
     ):
         if len(residues) == 0:
             continue
-        new_chain_id = ascii_uppercase[i]
+        new_chain_id = _index_to_chain_id(len(new_chains))
         if chain_type in ('Polypeptide(L)', 'Polyribonucleotide'):
             new_chain = PolymerChain(
                 chain_id = new_chain_id,

--- a/crimm/IO/PDBParser.py
+++ b/crimm/IO/PDBParser.py
@@ -1,4 +1,3 @@
-from string import ascii_uppercase
 import warnings
 import pathlib
 from Bio.PDB.PDBParser import PDBParser as _PDBParser
@@ -9,16 +8,9 @@ from Bio.Data.PDBData import (
 from crimm.IO.StructureBuilder import StructureBuilder
 from crimm.StructEntities.Chain import Solvent, Heterogens, PolymerChain, Chain, Ion
 from crimm.Data.components_dict import CHARMM_PDB_ION_NAMES
+from crimm.Utils.StructureUtils import index_to_letters
 
 protein_letters_3to1.update({'HSD': 'H', 'HSE': 'H', 'HSP': 'H'})
-
-
-def _index_to_chain_id(index, chain_id=''):
-    """Return spreadsheet-style chain IDs for indices beyond 25."""
-    chain_id = ascii_uppercase[index % 26] + chain_id
-    if (next_index := index // 26) > 0:
-        return _index_to_chain_id(next_index - 1, chain_id)
-    return chain_id
 
 
 def check_chain_type(residues, resname_lookup, extended_lookup=None):
@@ -96,7 +88,7 @@ def convert_chains(chains):
     ):
         if len(residues) == 0:
             continue
-        new_chain_id = _index_to_chain_id(len(new_chains))
+        new_chain_id = index_to_letters(len(new_chains))
         if chain_type in ('Polypeptide(L)', 'Polyribonucleotide'):
             new_chain = PolymerChain(
                 chain_id = new_chain_id,

--- a/crimm/IO/PDBString.py
+++ b/crimm/IO/PDBString.py
@@ -1,4 +1,5 @@
 import warnings
+from string import ascii_uppercase, ascii_lowercase, digits
 
 # Allowed Elements
 from Bio.Data.IUPACData import atom_weights
@@ -13,6 +14,33 @@ _CHARMM_ATOM_FORMAT_STRING = (
 _TER_FORMAT_STRING = (
     "TER   %5i      %3s %c%4i%c                                                      \n"
 )
+_PDB_CHAIN_IDS = ascii_uppercase + ascii_lowercase + digits
+
+
+def _copy_with_standard_pdb_chain_ids(entity):
+    """Return a copy of entity with single-character chain IDs for PDB export."""
+    export_entity = entity.copy()
+    if export_entity.level == 'C':
+        chains = [export_entity]
+    elif export_entity.level == 'M':
+        chains = list(export_entity.child_list)
+    elif export_entity.level == 'S':
+        if len(export_entity.child_list) == 0:
+            return export_entity
+        chains = list(export_entity.child_list[0].child_list)
+    else:
+        return export_entity
+
+    if len(chains) > len(_PDB_CHAIN_IDS):
+        raise ValueError(
+            "Standard PDB output can only remap up to "
+            f"{len(_PDB_CHAIN_IDS)} chains into unique single-character IDs. "
+            "Serialize chains separately or use CHARMM-format PDB/mmCIF output instead."
+        )
+
+    for i, chain in enumerate(chains):
+        chain.id = _PDB_CHAIN_IDS[i]
+    return export_entity
 
 def _get_atom_line_with_parent_info(
         atom: Atom, trunc_resname=False, use_charmm_format=False, convert_water=False
@@ -213,7 +241,8 @@ def _get_atom_line(
 def get_pdb_str(
         entity, reset_serial=True,
         include_alt=False, trunc_resname=False, 
-        use_charmm_format=False, convert_water=False
+        use_charmm_format=False, convert_water=False,
+        pdb_compatible_chain_ids=False
     ):
     """Return the PDB string of the entity.
     Parameters
@@ -230,11 +259,17 @@ def get_pdb_str(
         Whether to use CHARMM PDB format (no chain ID), by default False.
     convert_water : bool, optional
         Whether to convert common water residue names to HOH, by default False.
+    pdb_compatible_chain_ids : bool, optional
+        Whether to renumber chain IDs in a temporary copy so standard PDB output
+        stays within the single-character chain-ID limit, by default False.
     Returns
     -------
     str
         The PDB string of the entity.
     """
+    if pdb_compatible_chain_ids and not use_charmm_format:
+        entity = _copy_with_standard_pdb_chain_ids(entity)
+
     if reset_serial and hasattr(entity, 'reset_atom_serial_numbers'):
         entity.reset_atom_serial_numbers(include_alt=include_alt)
 

--- a/crimm/IO/PDBString.py
+++ b/crimm/IO/PDBString.py
@@ -14,10 +14,11 @@ _CHARMM_ATOM_FORMAT_STRING = (
 _TER_FORMAT_STRING = (
     "TER   %5i      %3s %c%4i%c                                                      \n"
 )
-_PDB_CHAIN_IDS = ascii_uppercase + ascii_lowercase + digits
+_STANDARD_PDB_CHAIN_IDS = ascii_uppercase + ascii_lowercase + digits
+_CHAIN_ID_POLICIES = {"preserve", "renumber"}
 
 
-def _copy_with_standard_pdb_chain_ids(entity):
+def _make_standard_pdb_export_copy(entity):
     """Return a copy of entity with single-character chain IDs for PDB export."""
     export_entity = entity.copy()
     if export_entity.level == 'C':
@@ -31,16 +32,26 @@ def _copy_with_standard_pdb_chain_ids(entity):
     else:
         return export_entity
 
-    if len(chains) > len(_PDB_CHAIN_IDS):
+    if len(chains) > len(_STANDARD_PDB_CHAIN_IDS):
         raise ValueError(
             "Standard PDB output can only remap up to "
-            f"{len(_PDB_CHAIN_IDS)} chains into unique single-character IDs. "
+            f"{len(_STANDARD_PDB_CHAIN_IDS)} chains into unique single-character IDs. "
             "Serialize chains separately or use CHARMM-format PDB/mmCIF output instead."
         )
 
     for i, chain in enumerate(chains):
-        chain.id = _PDB_CHAIN_IDS[i]
+        chain.id = _STANDARD_PDB_CHAIN_IDS[i]
     return export_entity
+
+
+def _normalize_chain_id_policy(chain_id_policy):
+    if chain_id_policy not in _CHAIN_ID_POLICIES:
+        valid = ", ".join(sorted(_CHAIN_ID_POLICIES))
+        raise ValueError(
+            f"Unknown chain_id_policy '{chain_id_policy}'. "
+            f"Expected one of: {valid}."
+        )
+    return chain_id_policy
 
 def _get_atom_line_with_parent_info(
         atom: Atom, trunc_resname=False, use_charmm_format=False, convert_water=False
@@ -242,7 +253,7 @@ def get_pdb_str(
         entity, reset_serial=True,
         include_alt=False, trunc_resname=False, 
         use_charmm_format=False, convert_water=False,
-        pdb_compatible_chain_ids=False
+        chain_id_policy="preserve"
     ):
     """Return the PDB string of the entity.
     Parameters
@@ -259,16 +270,19 @@ def get_pdb_str(
         Whether to use CHARMM PDB format (no chain ID), by default False.
     convert_water : bool, optional
         Whether to convert common water residue names to HOH, by default False.
-    pdb_compatible_chain_ids : bool, optional
-        Whether to renumber chain IDs in a temporary copy so standard PDB output
-        stays within the single-character chain-ID limit, by default False.
+    chain_id_policy : {"preserve", "renumber"}, optional
+        Policy for standard PDB chain IDs. ``"preserve"`` keeps the original
+        chain IDs and raises if they exceed the one-character PDB limit.
+        ``"renumber"`` writes from a temporary copy with remapped single-
+        character chain IDs.
     Returns
     -------
     str
         The PDB string of the entity.
     """
-    if pdb_compatible_chain_ids and not use_charmm_format:
-        entity = _copy_with_standard_pdb_chain_ids(entity)
+    chain_id_policy = _normalize_chain_id_policy(chain_id_policy)
+    if chain_id_policy == "renumber" and not use_charmm_format:
+        entity = _make_standard_pdb_export_copy(entity)
 
     if reset_serial and hasattr(entity, 'reset_atom_serial_numbers'):
         entity.reset_atom_serial_numbers(include_alt=include_alt)

--- a/crimm/IO/PDBString.py
+++ b/crimm/IO/PDBString.py
@@ -26,7 +26,7 @@ def _get_atom_line_with_parent_info(
     segid = residue.segid
     hetfield, resseq, icode = residue.id
     if (chain:=residue.parent) is not None:
-        chain_id = chain.get_id()[0]
+        chain_id = chain.get_id()
     else:
         chain_id = '_'
     return _get_atom_line(
@@ -35,16 +35,25 @@ def _get_atom_line_with_parent_info(
         use_charmm_format=use_charmm_format
     )
 
-def _get_ter_line(atom: Atom, trunc_resname=False):
+def _get_ter_line(atom: Atom, trunc_resname=False, use_charmm_format=False):
     """Return the parent info of the atom (PRIVATE). Atom must have a parent residue."""
     residue = atom.parent
     resname = residue.resname
     hetfield, resseq, icode = residue.id
     if (chain:=residue.parent) is not None:
-        chain_id = chain.get_id()[0]
+        chain_id = chain.get_id()
     else:
         # no chain info, no standard TER line
         return 'TER\n'
+
+    if use_charmm_format:
+        return 'TER\n'
+
+    if len(chain_id) > 1:
+        raise ValueError(
+            f"Chain ID '{chain_id}' exceeds the standard PDB limit of 1 character. "
+            "Use CHARMM-format PDB output or an mmCIF writer instead."
+        )
     
     if len(resname) > 3 and trunc_resname:
         # Truncate residue name to 3 characters so it does not mess up
@@ -90,6 +99,11 @@ def _get_atom_line(
         format_string = _CHARMM_ATOM_FORMAT_STRING
         record_type = "ATOM  "
     else:
+        if len(chain_id) > 1:
+            raise ValueError(
+                f"Chain ID '{chain_id}' exceeds the standard PDB limit of 1 "
+                "character. Use CHARMM-format PDB output or an mmCIF writer instead."
+            )
         format_string = _ATOM_FORMAT_STRING
 
     if len(resname) > 3 and trunc_resname:
@@ -243,6 +257,8 @@ def get_pdb_str(
             pdb_str += _get_atom_line_with_parent_info(
                 atom, trunc_resname, use_charmm_format, convert_water
             )
-        pdb_str += _get_ter_line(atoms[-1], trunc_resname)
+        pdb_str += _get_ter_line(
+            atoms[-1], trunc_resname, use_charmm_format=use_charmm_format
+        )
     pdb_str += 'END\n'
     return pdb_str

--- a/crimm/IO/PDBString.py
+++ b/crimm/IO/PDBString.py
@@ -96,6 +96,11 @@ def _get_atom_line(
 
     if use_charmm_format:
         # CHARMM format does not have chain id and record type is always ATOM
+        if len(segid) > 4:
+            raise ValueError(
+                f"SEGID '{segid}' exceeds the CHARMM PDB limit of 4 characters. "
+                "Use a shorter segid or the default PSF/CRD loading path instead."
+            )
         format_string = _CHARMM_ATOM_FORMAT_STRING
         record_type = "ATOM  "
     else:

--- a/crimm/IO/PSFWriter.py
+++ b/crimm/IO/PSFWriter.py
@@ -19,6 +19,7 @@ from crimm.StructEntities.Residue import Residue
 from crimm.StructEntities.Chain import BaseChain
 from crimm.StructEntities.Model import Model
 from crimm.StructEntities.TopoElements import CMap
+from crimm.Utils.StructureUtils import polymer_chain_to_charmm_segid
 
 
 class PSFWriter:
@@ -359,9 +360,7 @@ class PSFWriter:
         """Assign automatic segment IDs to chains without segids.
 
         Rules:
-        - Protein: PRO{A,B,C,...}
-        - DNA: DNA{A,B,C,...}
-        - RNA: RNA{A,B,C,...}
+        - Polymer chains: shared CHARMM-safe segid policy based on chain.id
         - Solvent: SOLV (single segment for all waters)
         - Ion: IONS (single segment for all ions)
         - Ligand/Other: LIG{A,B,C,...}
@@ -393,12 +392,16 @@ class PSFWriter:
             # Determine chain type
             chain_type = getattr(chain, "chain_type", None) or ""
 
-            if "polypeptide" in chain_type.lower():
-                prefix = "PRO"
-            elif "polydeoxyribonucleotide" in chain_type.lower():
-                prefix = "DNA"
-            elif "polyribonucleotide" in chain_type.lower():
-                prefix = "RNA"
+            if (
+                "polypeptide" in chain_type.lower()
+                or "polydeoxyribonucleotide" in chain_type.lower()
+                or "polyribonucleotide" in chain_type.lower()
+            ):
+                segid = polymer_chain_to_charmm_segid(chain)
+                self._segid_map[chain] = segid
+                for residue in chain:
+                    residue.segid = segid
+                continue
             elif chain_type.lower() == "solvent":
                 # By default, all waters share SOLV segid
                 # If separate_crystal_segids=True, crystallographic waters get CRWT

--- a/crimm/Utils/StructureUtils.py
+++ b/crimm/Utils/StructureUtils.py
@@ -1,10 +1,13 @@
-from string import ascii_uppercase
+from string import ascii_uppercase, digits
 from Bio.Data.PDBData import protein_letters_3to1_extended
 from Bio.Data.PDBData import nucleic_letters_3to1_extended
 from crimm.Data.components_dict import nucleic_letters_1to3
 from crimm.StructEntities.Chain import Solvent, Ion, PolymerChain
 from copy import copy
 import numpy as np
+
+
+_BASE36_ALPHABET = digits + ascii_uppercase
 
 def index_to_letters(index, letter = ''):
     """Enumerate a sequence of letters based on the alphabet from a integer number.
@@ -40,6 +43,79 @@ def letters_to_index(letters):
         cur_index = ascii_uppercase.find(l)+1
         index += cur_index * (26 ** i)
     return index
+
+
+def _to_base36(value: int) -> str:
+    """Encode a non-negative integer as an uppercase base36 string."""
+    if value < 0:
+        raise ValueError("value must be non-negative")
+    if value == 0:
+        return "0"
+
+    encoded = []
+    while value:
+        value, remainder = divmod(value, 36)
+        encoded.append(_BASE36_ALPHABET[remainder])
+    return "".join(reversed(encoded))
+
+
+def compact_charmm_chain_id(chain_id: str, max_len: int = 3) -> str:
+    """Return a compact uppercase token for CHARMM's 4-character SEGID limit."""
+    chain_id = str(chain_id).upper()
+    if len(chain_id) <= max_len and chain_id.isalnum():
+        return chain_id
+    if not chain_id.isalpha():
+        raise ValueError(
+            f"Cannot compact chain ID '{chain_id}' into a CHARMM SEGID token."
+        )
+
+    compact = _to_base36(letters_to_index(chain_id))
+    if len(compact) > max_len:
+        raise ValueError(
+            f"Chain ID '{chain_id}' cannot be represented within CHARMM's "
+            "4-character SEGID limit."
+        )
+    return compact
+
+
+def polymer_chain_id_to_charmm_segid(chain_type: str, chain_id: str) -> str:
+    """Map a polymer chain ID to a single CHARMM-safe 4-character SEGID policy.
+
+    Rules:
+        Protein A   -> PROA
+        Protein AA  -> PRAA
+        RNA A       -> RNAA
+        RNA AA      -> RRAA
+        DNA A       -> DNAA
+        DNA AA      -> DRAA
+        Longer IDs  -> type letter + compact token
+    """
+    chain_id = str(chain_id).upper()
+    normalized_type = (chain_type or "").lower()
+
+    if "polydeoxyribonucleotide" in normalized_type:
+        full_prefix = "DNA"
+        rollover_prefix = "DR"
+        fallback_prefix = "D"
+    elif "polyribonucleotide" in normalized_type:
+        full_prefix = "RNA"
+        rollover_prefix = "RR"
+        fallback_prefix = "R"
+    else:
+        full_prefix = "PRO"
+        rollover_prefix = "PR"
+        fallback_prefix = "P"
+
+    if len(chain_id) == 1 and chain_id.isalnum():
+        return f"{full_prefix}{chain_id}"
+    if len(chain_id) == 2 and chain_id.isalnum():
+        return f"{rollover_prefix}{chain_id}"
+    return f"{fallback_prefix}{compact_charmm_chain_id(chain_id)}"
+
+
+def polymer_chain_to_charmm_segid(chain) -> str:
+    """Return the CHARMM SEGID for a polymer chain object."""
+    return polymer_chain_id_to_charmm_segid(chain.chain_type, chain.id)
 
 def get_coords(entity, include_alt=False):
     """Get atom coordinates from any structure entity level or a list of entities.

--- a/crimm/Visualization/NGLVisualization.py
+++ b/crimm/Visualization/NGLVisualization.py
@@ -20,7 +20,8 @@ class NGLStructure(nv.Structure):
     def get_structure_string(self):
         return get_pdb_str(
             self.entity, include_alt=False, trunc_resname=True, 
-            use_charmm_format=False, convert_water=True
+            use_charmm_format=False, convert_water=True,
+            pdb_compatible_chain_ids=True
         )
 
 class NGLRDKitStructure(nv.Structure):

--- a/crimm/Visualization/NGLVisualization.py
+++ b/crimm/Visualization/NGLVisualization.py
@@ -21,7 +21,7 @@ class NGLStructure(nv.Structure):
         return get_pdb_str(
             self.entity, include_alt=False, trunc_resname=True, 
             use_charmm_format=False, convert_water=True,
-            pdb_compatible_chain_ids=True
+            chain_id_policy='renumber'
         )
 
 class NGLRDKitStructure(nv.Structure):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "crimm"
-version = "2026.1.7"
+version = "2026.1.8"
 authors = [
   { name="Truman Xu", email="ziqiaoxu@umich.edu" },
   { name="Stanislav Cherepanov", email="stanislc@umich.edu" },


### PR DESCRIPTION
## Summary

- replace the fixed 26-letter chain renaming in `PDBParser.convert_chains()` with rollover chain IDs
- keep generated chain IDs contiguous when empty organized groups are skipped
- fix the `IndexError` raised on PDB inputs that parse into more than 26 chains

## Root Cause

`convert_chains()` indexed `ascii_uppercase[i]` directly, so parsing failed at chain 27.

## Validation

- `/home/stanislc/software/mambaforge/envs/chm_12.9/bin/python -c "from crimm.IO import PDBParser; p='/home/jocoop/HepB_study/hex_virus_build/6htx_58h.pdb'; s=PDBParser(QUIET=True).get_structure(p, '6htx_58h'); print(len(s.child_list[0].child_list))"`
- Result: `28` parsed chains with no exception

## Notes

- The local archive branch `local/archive/fix-pdbparser-chain-overflow-with-test` preserves the regression test version of this fix; the synced PR branch is code-only by design.
